### PR TITLE
No speed difference between sparsities

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+Having Trouble...
+
 # Auto-Compressing Subset Pruning for Semantic Image Segmentation
 
 Pytorch Implementation of [Auto-Compressing Subset Pruning for Semantic Image Segmentation](https://arxiv.org/abs/2201.11103).


### PR DESCRIPTION
Thanks for your great work!
I have some trouble running tests with your code, but I could not submit any issues so I'm leaving messages here...


Q1: When I ran `test.sh` on cityscapes dataset, it gave me the warning:
```
/home/yan/anaconda3/envs/ML3.9/lib/python3.9/site-packages/acosp/inject.py:119: UserWarning: Incorrect number of channels are masked: tensor([1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
        1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
        1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
        1., 1., 1., 1., 1., 1., 1., 1., 1., 1.]) for 32 number of remaining elements
```
what does it mean?


Q2: There is no speed difference between sparsities. I noticed you had implemented `soft_to_channel_sparse` in `inject.py`, and I think it is used to convert masked convs to sparse normal ones, which have fewer flops.  Could you tell me how to use it to boot inference at runtime?

Thanks in advance.